### PR TITLE
chore(ci): added taplo toml autoformatter config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -246,6 +246,7 @@
             rustToolchain
             pkgs.gnuplot
             pkgs.teleport_13
+            pkgs.taplo
             (pkgs.writeShellScriptBin "ci" ''nix/ci.sh "$@"'')
           ] ++ hostDeps ++ extraHostDeps;
         } // env // extraEnv);

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,14 @@
+exclude = ["**/target/**/*", ".direnv/**/*"]
+
+[formatting]
+align_comments = false
+column_width = 88
+indent_string = "	"
+reoder_arrays = true
+reorder_keys = true
+trailing_newline = true
+
+[[rule]]
+keys = ["package"]
+[rule.formatting]
+reorder_keys = false


### PR DESCRIPTION
This does not enforce it in CI, but at least it codifies the format and makes the tool available, for people who configure their editors to format toml.